### PR TITLE
Added /etc/awslogs/awscli.conf section

### DIFF
--- a/core-2az.json
+++ b/core-2az.json
@@ -1106,7 +1106,18 @@
                 "mode": "000444",
                 "owner": "root",
                 "group": "root"
-              }
+              },
+              "/etc/awslogs/awscli.conf": {
+                "content": { "Fn::Join": [ "", [
+                  "[plugins]\n",
+                  "cwlogs = cwlogs\n",
+                  "[default]\n",
+                  "region = ", { "Ref" : "AWS::Region" }, "\n"
+                ] ] },
+                "mode": "000444",
+                "owner": "root",
+                "group": "root"
+              }                                            
             },
             "commands" : {
               "01_create_state_directory" : {

--- a/core-3az.json
+++ b/core-3az.json
@@ -1346,7 +1346,18 @@
                 "mode": "000444",
                 "owner": "root",
                 "group": "root"
-              }
+              },
+              "/etc/awslogs/awscli.conf": {
+                "content": { "Fn::Join": [ "", [
+                  "[plugins]\n",
+                  "cwlogs = cwlogs\n",
+                  "[default]\n",
+                  "region = ", { "Ref" : "AWS::Region" }, "\n"
+                ] ] },
+                "mode": "000444",
+                "owner": "root",
+                "group": "root"
+              }                                            
             },
             "commands" : {
               "01_create_state_directory" : {


### PR DESCRIPTION
In the "files" section of the "install_logs" configset I added a files section to add entries into the /etc/awslogs/awscli.conf file. 

They key entry here is the explicit entry for the AWS region for the CloudWatch logs. 

This updates the awscli.conf file with the correct region being used elsewhere in the Cf template. Without this entry, awslogs will default to us-east-1 for the location of the CloudWatch logs. This can be a surprise if your template launches resources elsewhere.